### PR TITLE
MAINT: update recipe run reqs to require most recent q2-pkg builds

### DIFF
--- a/.github/workflows/ci-dev.yaml
+++ b/.github/workflows/ci-dev.yaml
@@ -9,5 +9,5 @@ jobs:
   ci:
     uses: qiime2/distributions/.github/workflows/lib-ci-dev.yaml@dev
     with:
-      distro: metagenome
+      distro: moshpit
       recipe-path: 'conda-recipe'

--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -18,8 +18,8 @@ requirements:
     - python {{ python }}
     - pip
     - click >=8.1
-    - qiime2 {{ qiime2_epoch }}.*
-    - q2cli {{ qiime2_epoch }}.*
+    - qiime2 >={{ qiime2 }}
+    - q2cli >={{ q2cli }}
   build:
   - python {{ python }}
   - setuptools


### PR DESCRIPTION
hey @misialq - i'm doing some recipe maintenance in response to @VinzentRisch's RNANorm issue. updating our q2 version reqs to match the latest build available will fix this issue, so that's what you'll see me adding across all of the moshpit/pathogenome plugins. lmk if you have any questions!