### PR TITLE
LANG: python 3.12 update & version templating

### DIFF
--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -17,7 +17,7 @@ requirements:
   run:
     - python {{ python }}
     - pip
-    - click >=8.1
+    - click {{ click }}
     - qiime2 >={{ qiime2 }}
     - q2cli >={{ q2cli }}
   build:


### PR DESCRIPTION
As part of this update, i am moving all version pins into the seed environments (out of individual plugins). This way we have a single source of truth for immediate dependency versioning per distro.

We'll wait to merge this until the canonical distributions PR is passing; this is just to ensure all testing is done in a cohesive environment (i.e. distributions will pull from all repo branches with this name, install the env from there and run tests).